### PR TITLE
specify fftw dep in Cray toolchain easyconfigs as an external dep

### DIFF
--- a/easybuild/easyconfigs/c/CrayCCE/CrayCCE-5.1.29.eb
+++ b/easybuild/easyconfigs/c/CrayCCE/CrayCCE-5.1.29.eb
@@ -8,6 +8,6 @@ description = """Toolchain using Cray compiler wrapper, using PrgEnv-cray module
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
-dependencies = [('fftw', '3.3.4.0')]
+dependencies = [('fftw/3.3.4.0', EXTERNAL_MODULE)]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/c/CrayCCE/CrayCCE-5.2.25.eb
+++ b/easybuild/easyconfigs/c/CrayCCE/CrayCCE-5.2.25.eb
@@ -8,6 +8,6 @@ description = """Toolchain using Cray compiler wrapper, using PrgEnv-cray module
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
-dependencies = [('fftw', '3.3.4.2')]
+dependencies = [('fftw/3.3.4.2', EXTERNAL_MODULE)]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/c/CrayGNU/CrayGNU-5.1.29.eb
+++ b/easybuild/easyconfigs/c/CrayGNU/CrayGNU-5.1.29.eb
@@ -8,6 +8,6 @@ description = """Toolchain using Cray compiler wrapper, using PrgEnv-gnu module.
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
-dependencies = [('fftw', '3.3.4.0')]
+dependencies = [('fftw/3.3.4.0', EXTERNAL_MODULE)]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/c/CrayGNU/CrayGNU-5.2.25.eb
+++ b/easybuild/easyconfigs/c/CrayGNU/CrayGNU-5.2.25.eb
@@ -8,6 +8,6 @@ description = """Toolchain using Cray compiler wrapper, using PrgEnv-gnu module.
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
-dependencies = [('fftw', '3.3.4.2')]
+dependencies = [('fftw/3.3.4.2', EXTERNAL_MODULE)]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/c/CrayIntel/CrayIntel-5.1.29.eb
+++ b/easybuild/easyconfigs/c/CrayIntel/CrayIntel-5.1.29.eb
@@ -8,6 +8,6 @@ description = """Toolchain using Cray compiler wrapper, using PrgEnv-intel modul
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
-dependencies = [('fftw', '3.3.4.0')]
+dependencies = [('fftw/3.3.4.0', EXTERNAL_MODULE)]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/c/CrayIntel/CrayIntel-5.2.25.eb
+++ b/easybuild/easyconfigs/c/CrayIntel/CrayIntel-5.2.25.eb
@@ -8,6 +8,6 @@ description = """Toolchain using Cray compiler wrapper, using PrgEnv-intel modul
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
-dependencies = [('fftw', '3.3.4.2')]
+dependencies = [('fftw/3.3.4.2', EXTERNAL_MODULE)]
 
 moduleclass = 'toolchain'


### PR DESCRIPTION
for https://github.com/hpcugent/easybuild-easyconfigs/pull/1538

depends on https://github.com/hpcugent/easybuild-framework/pull/1230, which is about to be merged